### PR TITLE
remove pass-by-reference

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -95,7 +95,7 @@ class syntax_plugin_nslist extends DokuWiki_Syntax_Plugin {
 
         // read the directory
         $result = array();
-        search(&$result,$conf['datadir'],'search_universal',$opts,$data['dir']);
+        search($result,$conf['datadir'],'search_universal',$opts,$data['dir']);
 
         if($data['dsort']){
             usort($result,array($this,'_sort_date'));


### PR DESCRIPTION
This change fixes breaking the wiki (Adora Belle) when running on PHP 5.4.8.

pass-by-reference was removed from PHP as of 5.4
see: http://php.net/manual/en/language.references.pass.php
