### PR TITLE
Feature:liststyle for depth>1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# nslist: Plugin for Dokuware
+# nslist: Plugin for DokuWiki
 Namespace listing plugin
+
+Have a look at [DokuWiki: nslist Plugin](https://www.dokuwiki.org/plugin:nslist?s[]=nslist)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# nslist: Plugin for Dokuware
+Namespace listing plugin

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   nslist
 author Andreas Gohr
 email  dokuwiki@cosmocode.de
-date   2016-01-24
+date   2018-09-18
 name   Namespace Listing
 desc   List all pages in a given namespace
 url    http://www.dokuwiki.org/plugin:nslist

--- a/syntax.php
+++ b/syntax.php
@@ -60,7 +60,8 @@ class syntax_plugin_nslist extends DokuWiki_Syntax_Plugin {
             'depth' => 1,
             'date'  => 1,
             'dsort' => 1
-        );
+            ,'liststyle' => 'default'
+            );
 
         list($ns,$params) = explode(' ',$match,2);
         $ns = cleanID($ns);
@@ -70,10 +71,12 @@ class syntax_plugin_nslist extends DokuWiki_Syntax_Plugin {
         if(preg_match('/\b(\d+)\b/i',$params,$m))   $conf['depth'] = $m[1];
         if($ns) $conf['ns'] = $ns;
 
+        if(preg_match('/liststyle=([a-z\-]+)\&?/i',$params,$m)) $conf['liststyle'] = $m[1]; //parse parameter "liststyle"
+
         $conf['dir'] = str_replace(':','/',$conf['ns']);
 
         // prepare data
-        return $conf;
+        return $conf; //conf will become data by function render later
     }
 
     /**
@@ -107,7 +110,20 @@ class syntax_plugin_nslist extends DokuWiki_Syntax_Plugin {
         foreach($result as $item){
             $R->listitem_open(1);
             $R->listcontent_open();
-            $R->internallink(':'.$item['id']);
+            
+            //Different behaviour as of Liststyle- Param
+            if($data['liststyle'] == 'default') {
+                //no special parameter given, use default = empty
+                $item['id_name'] = '';
+            }elseif($data['liststyle'] == 'full')
+            {
+                $item['id_name'] = $item['id']; //full name of space
+            }elseif($data['liststyle'] == 'relative')
+            {
+                $item['id_name'] = substr($item['id'],strlen($data['ns'])+1); //strip off given namespace + ':'
+            };
+            
+            $R->internallink(':'.$item['id'],$item['id_name']);
             if($data['date']) $R->cdata(' '.dformat($item['mtime']));
 
             $R->listcontent_close();


### PR DESCRIPTION
I needed use depth > 1, but resulting list was quite unstructured.

So i added Parameter liststyle=[STYLE] to make it more structured.
where style can be one of:
default - the same as not given
relative - will print relative names for pages
full - will print fully qualified pagenames

Other styles could also be implemented, but this was already fine for my needs.
What do you think?
Regards, Daniel